### PR TITLE
Use cloudflare CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 	================================================== -->
     <!-- <link rel="shortcut icon" href="images/favicon.ico"> -->
 <script type="text/javascript"
-  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
The mathjax CDN is getting retired at some point. The `//` just means whatever protocol (`http`/`https`) the page is using.