### PR TITLE
Update packages

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,18 +1,31 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
+
 [[Artifacts]]
-deps = ["Pkg"]
-git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
-version = "1.3.0"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[Crayons]]
-git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
-uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
-version = "4.0.4"
+[[BitFlags]]
+git-tree-sha1 = "2dc09997850d68179b69dafb58ae806167a32b1b"
+uuid = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
+version = "0.1.8"
+
+[[CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "59939d8a997469ee05c4b4944560a820f9ba0d73"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.7.4"
+
+[[ConcurrentUtilities]]
+deps = ["Serialization", "Sockets"]
+git-tree-sha1 = "8cfa272e8bdedfa88b6aefbbca7c19f1befac519"
+uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
+version = "2.3.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -20,156 +33,254 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [[DelimitedFiles]]
 deps = ["Mmap"]
+git-tree-sha1 = "9e2f36d3c96a820c678f2f1f1782582fcf685bae"
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-
-[[Distributed]]
-deps = ["Random", "Serialization", "Sockets"]
-uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+version = "1.9.1"
 
 [[DocStringExtensions]]
-deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "50ddf44c53698f5e784bbebb3f4b21c5807401b1"
+deps = ["LibGit2"]
+git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.3"
+version = "0.9.3"
+
+[[Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[ExceptionUnwrapping]]
+deps = ["Test"]
+git-tree-sha1 = "dcb08a0d93ec0b1cdc4af184b26b591e9695423a"
+uuid = "460bff9d-24e4-43bc-9d9f-a8973cb893f4"
+version = "0.1.10"
 
 [[ExprTools]]
-git-tree-sha1 = "10407a39b87f29d47ebaca8edbc75d7c302ff93e"
+git-tree-sha1 = "27415f162e6028e81c72b82ef756bf321213b6ec"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
-version = "0.1.3"
+version = "0.1.10"
 
 [[FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[Franklin]]
-deps = ["Dates", "DelimitedFiles", "DocStringExtensions", "ExprTools", "FranklinTemplates", "HTTP", "Literate", "LiveServer", "Logging", "Markdown", "NodeJS", "OrderedCollections", "Pkg", "REPL", "Random"]
-git-tree-sha1 = "f92852d1d22d9d5f36f1ef11647718153bcfd895"
+deps = ["Dates", "DelimitedFiles", "DocStringExtensions", "ExprTools", "FranklinTemplates", "HTTP", "Literate", "LiveServer", "Logging", "Markdown", "NodeJS", "OrderedCollections", "Pkg", "REPL", "Random", "TOML"]
+git-tree-sha1 = "31e70717e0640d6576fe04d611a33df1c9c312d6"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
-version = "0.10.28"
+version = "0.10.95"
 
 [[FranklinTemplates]]
 deps = ["LiveServer"]
-git-tree-sha1 = "7159314a91990842cfa6484f3a0fd5666015a7c2"
+git-tree-sha1 = "c01813a615149ddb3b3d133f33de29d642fbe57b"
 uuid = "3a985190-f512-4703-8d38-2a7944ed5916"
-version = "0.8.12"
+version = "0.10.2"
 
 [[HTTP]]
-deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets", "URIs"]
-git-tree-sha1 = "942c1a9c750bbe79912b7bd060a420932afd35b8"
+deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
+git-tree-sha1 = "abbbb9ec3afd783a7cbd82ef01dcd088ea051398"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.9.3"
+version = "1.10.1"
 
-[[IniFile]]
-deps = ["Test"]
-git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
-uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
-version = "0.5.0"
+[[IOCapture]]
+deps = ["Logging", "Random"]
+git-tree-sha1 = "8b72179abc660bfab5e28472e019392b97d0985c"
+uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+version = "0.2.4"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JLLWrappers]]
-git-tree-sha1 = "a431f5f2ca3f4feef3bd7a5e94b8b8d4f2f647a0"
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.2.0"
+version = "1.5.0"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.1"
+version = "0.21.4"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.4.0+0"
 
 [[LibGit2]]
-deps = ["Printf"]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.6.4+0"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.0+1"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[Literate]]
-deps = ["Base64", "JSON", "REPL"]
-git-tree-sha1 = "32b517d4d8219d3bbab199de3416ace45010bdb3"
+deps = ["Base64", "IOCapture", "JSON", "REPL"]
+git-tree-sha1 = "bad26f1ccd99c553886ec0725e99a509589dcd11"
 uuid = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
-version = "2.8.0"
+version = "2.16.1"
 
 [[LiveServer]]
-deps = ["Crayons", "FileWatching", "HTTP", "Pkg", "Sockets", "Test"]
-git-tree-sha1 = "7c2f32edab7941184a58ef56d589dac14e0ffa23"
+deps = ["HTTP", "LoggingExtras", "MIMEs", "Pkg", "Sockets", "Test"]
+git-tree-sha1 = "24d05efe53436b22a42bf2ae459f47c48b0c2603"
 uuid = "16fef848-5104-11e9-1b77-fb7a48bbb589"
-version = "0.6.0"
+version = "1.2.7"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[LoggingExtras]]
+deps = ["Dates", "Logging"]
+git-tree-sha1 = "c1dd6d7978c12545b4179fb6153b9250c96b0075"
+uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+version = "1.0.3"
+
+[[MIMEs]]
+git-tree-sha1 = "65f28ad4b594aebe22157d6fac869786a255b7eb"
+uuid = "6c6e2e6c-3030-632d-7369-2d6c69616d65"
+version = "0.1.4"
 
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[MbedTLS]]
-deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
-git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
+deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "NetworkOptions", "Random", "Sockets"]
+git-tree-sha1 = "c067a280ddc25f196b5e7df3877c6b226d390aaf"
 uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "1.0.3"
+version = "1.1.9"
 
 [[MbedTLS_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "0eef589dd1c26a3ac9d753fe1a8bcad63f956fa6"
+deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.16.8+1"
+version = "2.28.2+1"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2023.1.10"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
 [[NodeJS]]
 deps = ["Pkg"]
-git-tree-sha1 = "350ac618f41958e6e0f6b0d2005ae4547eb1b503"
+git-tree-sha1 = "905224bbdd4b555c69bb964514cfa387616f0d3a"
 uuid = "2bd173c7-0d6d-553b-b6af-13a54713934c"
-version = "1.1.1"
+version = "1.3.0"
+
+[[OpenSSL]]
+deps = ["BitFlags", "Dates", "MozillaCACerts_jll", "OpenSSL_jll", "Sockets"]
+git-tree-sha1 = "51901a49222b09e3743c65b8847687ae5fc78eb2"
+uuid = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
+version = "1.4.1"
+
+[[OpenSSL_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "cc6e1927ac521b659af340e0ca45828a3ffc748f"
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.0.12+0"
 
 [[OrderedCollections]]
-git-tree-sha1 = "d45739abcfc03b51f6a42712894a593f74c80a23"
+git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.3.3"
+version = "1.6.3"
 
 [[Parsers]]
-deps = ["Dates"]
-git-tree-sha1 = "50c9a9ed8c714945e01cd53a21007ed3865ed714"
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "8489905bcdbcfac64d1daa51ca07c0d8f0283821"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.15"
+version = "2.8.1"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.10.0"
+
+[[PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "03b4c25b43cb84cee5c90aa9b5ea0a78fd848d2f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.0"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "00805cd429dcb4870060ff49ef443486c262e38e"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.1"
 
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets"]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
-deps = ["Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
+[[SimpleBufferStream]]
+git-tree-sha1 = "874e8867b33a00e784c8a7e4b60afe9e037b74e1"
+uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
+version = "1.1.0"
+
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
 [[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[[TranscodingStreams]]
+git-tree-sha1 = "1fbeaaca45801b4ba17c251dd8603ef24801dd84"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.10.2"
+weakdeps = ["Random", "Test"]
+
+    [TranscodingStreams.extensions]
+    TestExt = ["Test", "Random"]
+
 [[URIs]]
-git-tree-sha1 = "7855809b88d7b16e9b029afd17880930626f54a2"
+git-tree-sha1 = "67db6cc7b3821e19ebe75791a9dd19c9b1188f2b"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.2.0"
+version = "1.5.1"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
@@ -177,3 +288,18 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+1"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.52.0+1"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+2"

--- a/_rss/head.xml
+++ b/_rss/head.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This is based on Yandex's https://yandex.com/support/zen/website/rss-modify.html
+
+The scope of this segment is the GLOBAL scope (variables defined in config.md).
+For instance 'website_url' or 'website_description'.
+
+Notes:
+* namespaces (xmlns): https://validator.w3.org/feed/docs/howto/declare_namespaces.html
+* best practices: https://www.rssboard.org/rss-profile
+* fd2rss convers markdown to html and fixes or removes relative links
+* fd_rss_feed_url is built out of {website_url}/{rss_file}.xml, you can change the
+rss_file variable in your config file if you want to use something different than 'feed'
+-->
+<rss version="2.0"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:media="http://search.yahoo.com/mrss/"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  xmlns:georss="http://www.georss.org/georss">
+
+  <channel>
+    <title>
+      <![CDATA[  {{fd2rss website_title}}  ]]>
+    </title>
+    <link> {{website_url}} </link>
+    <description>
+      <![CDATA[  {{fd2rss website_description}}  ]]>
+    </description>
+    <atom:link
+      href="{{fd_rss_feed_url}}"
+      rel="self"
+      type="application/rss+xml" />
+<!--
+* items will be added here in chronological order
+* the channel will then be closed
+-->

--- a/_rss/item.xml
+++ b/_rss/item.xml
@@ -1,0 +1,60 @@
+<!--
+This is based on Yandex's https://yandex.com/support/zen/website/rss-modify.html
+
+The scope of this segment is the LOCAL scope (page variables). For instance 'rss_title'.
+
+Notes:
+* the local var rss_description (or rss) *must* be given otherwise the item
+is not generated.
+* rss_title if not given is inferred from page title
+* rss_pubdate if not given is inferred from the date of last modification
+* the full content is not added by default but can be if the variable rss_full_content
+is set to true (either globally or locally).
+* RFC822 or RFC1123 is a date format required by RSS.
+* there is debate about supporting one or several enclosures
+(see https://www.rssboard.org/rss-profile#element-channel-item-enclosure).
+We use the conservative 'only one' approach by default but you could tweak this by
+defining your own `rss_enclosures` variable with a list of string and use that.
+-->
+<item>
+  <title>
+    <![CDATA[  {{fd2rss rss_title}}  ]]>
+  </title>
+  <link> {{fd_full_url}} </link>
+  <guid> {{fd_full_url}} </guid>
+  <description>
+    <![CDATA[  {{fd2rss rss_description}}  ]]>
+  </description>
+
+  <!-- note that fd_page_html is already HTML, so we don't use fd2rss here -->
+  {{if rss_full_content}}
+  <content:encoded>
+    <![CDATA[  {{fix_relative_links fd_page_html}} ]]>
+  </content:encoded>
+  {{end}}
+
+  <!-- RFC1123 enforces a RSS-compliant date formatting -->
+  <pubDate>{{RFC822 rss_pubdate}}</pubDate>
+
+  <!-- if given this must be an email, see specs -->
+  {{isnotempty rss_author}}
+  <author> {{rss_author}} </author>
+  {{end}}
+  {{isnotempty author}}
+  <atom:author>
+    <atom:name>{{author}}</atom:name>
+  </atom:author>
+  {{end}}
+
+  {{isnotempty rss_category}}
+  <category> {{rss_category}} </category>
+  {{end}}
+
+  {{isnotempty rss_comments}}
+  <comments> {{rss_comments}} </comments>
+  {{end}}
+
+  {{isnotempty rss_enclosure}}
+  <enclosure> {{rss_enclosure}} </enclosure>
+  {{end}}
+</item>

--- a/config.md
+++ b/config.md
@@ -7,7 +7,7 @@ The website_* must be defined for the RSS to work
 @def website_descr = "Differentiation tools in Julia"
 @def website_url   = "https://www.julialang.org"
 
-@def author = "Frames White, Miles Lubin"
+@def author = "Frames White, Miles Lubin, Guillaume Dalle"
 
 @def mintoclevel = 2
 

--- a/index.md
+++ b/index.md
@@ -79,7 +79,7 @@ These packages define derivatives for basic functions, and enable users to do th
   - [JuliaDiff/ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl/): Rules for Julia Base and standard libraries.
   - [JuliaDiff/ChainRulesTestUtils.jl](https://github.com/JuliaDiff/ChainRulesTestUtils.jl/): Tools for testing rules defined with ChainRulesCore.jl.
 - [ThummeTo/ForwardDiffChainRules.jl](https://github.com/ThummeTo/ForwardDiffChainRules.jl): Translate rules from ChainRulesCore.jl to make them compatible with ForwardDiff.jl
-- [JuliaDiff/DiffRules.jl](https://github.com/JuliaDiff/DiffRules.jl): Scalar rules used by ForwardDiff.jl, ReverseDiff.jl, and Tracker.jl
+- [JuliaDiff/DiffRules.jl](https://github.com/JuliaDiff/DiffRules.jl): Scalar rules used by e.g. ForwardDiff.jl, ReverseDiff.jl, Zygote.jl, Tracker.jl, and Symbolics.jl
 - [FluxML/ZygoteRules.jl](https://github.com/FluxML/ZygoteRules.jl): Some rules used by Zygote.jl (mostly deprecated in favor of ChainRules.jl).
 
 ### Interface

--- a/index.md
+++ b/index.md
@@ -3,87 +3,115 @@
 
 @@topmatter
 # JuliaDiff
-Differentiation tools in [Julia](https://julialang.org).
-[JuliaDiff on GitHub](https://github.com/JuliaDiff/)
+Differentiation tools in Julia
 @@
 
-## Stop approximating derivatives!
+## Computing derivatives
 
-Derivatives are required at the core of many numerical algorithms. Unfortunately, they are usually computed _inefficiently_ and _approximately_ by some variant of the finite difference approach
-$$ f'(x) \approx \frac{f(x+h) - f(x)}{h}, h \text{ small }. $$
-This method is _inefficient_ because it requires $ \Omega(n) $ evaluations of $ f : \mathbb{R}^n \to \mathbb{R} $ to compute the gradient $ \nabla f(x) = \left( \frac{\partial f}{\partial x_1}(x), \cdots, \frac{\partial f}{\partial x_n}(x)\right) $, for example. It is _approximate_ because we have to choose some finite, small value of the step length $ h $, balancing floating-point precision with mathematical approximation error.
+Derivatives are required by many numerical algorithms, even for functions $f$ given as chunks of computer code rather than simple mathematical expressions.
+There are various ways to compute the gradient, Jacobian or Hessian of such functions without tedious manual labor:
 
+- Symbolic differentiation, which uses [computer algebra](https://en.wikipedia.org/wiki/Computer_algebra) to work out explicit formulas
+- [Numerical differentiation](https://en.wikipedia.org/wiki/Numerical_differentiation), which relies on variants of the finite difference approximation $f'(x) \approx \frac{f(x+\varepsilon) - f(x)}{\varepsilon}$
+- [Automatic differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation) (AD), which reinterprets the code of $f$ either in "forward" or "reverse" mode
 
-#### What can we do instead?
-One option is to explicitly write down a function which computes the exact derivatives by using the rules that we know from calculus. However, this quickly becomes an error-prone and tedious exercise. **There is another way!** The field of [automatic differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation) provides methods for automatically computing _exact_ derivatives (up to floating-point error) given only the function $ f $ itself. Some methods use many fewer evaluations of $ f $ than would be required when using finite differences. In the best case, **the exact gradient of $ f $ can be evaluated for the cost of $ O(1) $ evaluations of $ f $ itself**.  The caveat is that $ f $ cannot be considered a black box; instead, we require either access to the source code of $ f $ or a way to plug in a special type of number using operator overloading.
+In machine learning, automatic differentiation is probably the most widely used paradigm, especially in reverse mode.
+However, each method has its own upsides and tradeoffs, which are detailed in the following papers, along with implementation techniques like "operator overloading" and "source transformation":
+
+> [_Automatic differentiation in machine learning: a survey_](https://jmlr.org/papers/v18/17-468.html), Baydin et al. (2018)
+
+> [_A review of automatic differentiation and its efficient implementation_](https://arxiv.org/abs/1811.05031), Margossian (2019)
 
 ## What is JuliaDiff?
-JuliaDiff is an informal organization which aims to unify and document packages written in [Julia](https://julialang.org) for evaluating derivatives. The technical features of Julia, namely, multiple dispatch, source code via reflection, JIT compilation, and first-class access to expression parsing make implementing and using techniques from automatic differentiation easier than ever before (in our biased opinion).
 
+JuliaDiff is an informal [GitHub organization](https://github.com/JuliaDiff/) which aims to unify and document packages written in [Julia](https://julialang.org) for evaluating derivatives.
+The technical features of Julia[^1] make implementing and using differentiation techniques easier than ever before (in our biased opinion).
+
+Discussions on JuliaDiff and its uses may be directed to the [Julia Discourse forum](https://discourse.julialang.org/).
+The ChainRules project maintains a [list of recommended reading](https://www.juliadiff.org/ChainRulesCore.jl/stable/FAQ.html#Where-can-I-learn-more-about-AD-?) for those after more information.
+The [autodiff.org](http://www.autodiff.org/) site serves as a portal for the academic community, though it is often out of date.
 
 ## The Big List
-This is a big list of Julia Automatic Differentiation (AD) packages and related tooling.
-As you can see there is a lot going on here.
-As with any such big lists it rapidly becomes out-dated.
-When you notice something that is out of date, or just plain wrong, please [submit a PR](https://github.com/JuliaDiff/juliadiff.github.io).
 
-This list aims to be comprehensive in coverage.
+What follows is a big list of Julia differentiation packages and related tooling, last updated in January 2024.
+If you notice something inaccurate or outdated, please [open an issue](https://github.com/JuliaDiff/juliadiff.github.io/issues) to signal it.
+The packages marked as inactive are those which have had no release in 2023.
+
+The list aims to be comprehensive in coverage.
 By necessity, this means it is not comprehensive in detail.
-It is worth investigating each package yourself to really understand its ins and outs, and pros and cons of its competitors.
+It is worth investigating each package yourself to really understand its ins and outs, and the pros and cons of its competitors.
 
-### Reverse-mode
-- [ReverseDiff.jl](https://github.com/JuliaDiff/ReverseDiff.jl): Operator overloading reverse-mode AD. Very well-established.
-- [Nabla.jl](https://github.com/invenia/Nabla.jl/): Operator overloading reverse-mode AD. Used in (its maintainer) Invenia's systems. 
-- [Tracker.jl](https://github.com/FluxML/Tracker.jl): Operator overloading reverse-mode AD. Most well-known for having been the AD used in earlier versions of the machine learning package [Flux.jl](https://github.com/FluxML/Flux.jl). No longer used by Flux.jl, but still used in several places in the Julia ecosystem.
-- [AutoGrad.jl](https://github.com/denizyuret/AutoGrad.jl): Operator overloading reverse-mode AD. Originally a port of the [Python Autograd package](https://github.com/HIPS/autograd). Primarily used in [Knet.jl](https://github.com/denizyuret/Knet.jl/).
+### Reverse mode automatic differentiation
 
-- [Zygote.jl](https://github.com/FluxML/Zygote.jl): IR-level source to source reverse-mode AD. Very widely used. Particularly notable for being the AD used by [Flux.jl](https://github.com/FluxML/Flux.jl). Also features a secret experimental source to source forward-mode AD.
-- [Yota.jl](https://github.com/dfdx/Yota.jl): IR-level source to source reverse-mode AD.
-- [XGrad.jl](https://github.com/dfdx/XGrad.jl): AST-level source to source reverse-mode AD. Not currently in active development.
-- [ReversePropagation.jl](https://github.com/dpsanders/ReversePropagation.jl): Scalar, tracing-based source to source reverse-mode AD.
-- [Enzyme.jl](https://github.com/wsmoses/Enzyme.jl): Scalar, LLVM source to source reverse-mode AD. Experimental.
-- [Diffractor.jl](https://github.com/JuliaDiff/Diffractor.jl): Next-gen IR-level source to source reverse-mode (and forward-mode) AD. In development.
+- [JuliaDiff/ReverseDiff.jl](https://github.com/JuliaDiff/ReverseDiff.jl): Operator overloading AD backend
+- [FluxML/Zygote.jl](https://github.com/FluxML/Zygote.jl): Source transformation AD backend
+- [EnzymeAD/Enzyme.jl](https://github.com/EnzymeAD/Enzyme.jl): LLVM-level source transformation AD backend
+- [dfdx/Yota.jl](https://github.com/dfdx/Yota.jl): Source transformation AD backend
+- [FluxML/Tracker.jl](https://github.com/FluxML/Tracker.jl): Operator overloading AD backend (mostly deprecated in favor of Zygote.jl)
 
-### Forward-mode
-- [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl): Scalar, operator overloading forward-mode AD. Very stable. Very well-established.
-- [ForwardDiff2](https://github.com/YingboMa//ForwardDiff2.jl): Experimental, non-scalar hybrid operator-overloading/source-to-source forward-mode AD. Not currently in development.
-- [Diffractor.jl](https://github.com/JuliaDiff/Diffractor.jl): Next-gen IR-level source to source forward-mode (and reverse-mode) AD. In development.
+### Forward mode automatic differentiation
 
-### Symbolic:
-- [Symbolics.jl](https://github.com/JuliaSymbolics/Symbolics.jl): A pure Julia [computer algebra system](https://en.wikipedia.org/wiki/Computer_algebra_system). While its docs focus on some particular domain use-case it is a fully general purpose system.
+- [JuliaDiff/ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl): Operator overloading AD backend
+- [JuliaDiff/PolyesterForwardDiff.jl](https://github.com/JuliaDiff/PolyesterForwardDiff.jl): Multithreaded version of ForwardDiff.jl
+- [JuliaDiff/Diffractor.jl](https://github.com/JuliaDiff/Diffractor.jl): Source transformation AD backend (experimental)
 
-### Exotic
-- [TaylorSeries.jl](https://github.com/JuliaDiff/TaylorSeries.jl): Computes polynomial expansions; which is the generalization of forward-mode AD to nth-order derivatives.
-- [NiLang.jl](https://github.com/GiggleLiu/NiLang.jl): [Reversible computing](https://en.wikipedia.org/wiki/Reversible_computing) [DSL](https://en.wikipedia.org/wiki/Domain-specific_language), where everything is differentiable by reversing.
-- [TaylorDiff.jl](https://github.com/JuliaDiff/TaylorDiff.jl): an efficient, linear-scaling implementation for higher-order directional derivatives, implemented with operator-overloading on statically-typed Taylor polynomials. In development.
+### Symbolic differentiation
 
-### Finite Differencing
-Yes, we said at the start to stop approximating derivatives, but these packages are faster and more accurate than you would expect finite differencing to ever achieve. 
-If you really need finite differencing, use these packages rather than implementing your own.
+- [JuliaSymbolics/Symbolics.jl](https://github.com/JuliaSymbolics/Symbolics.jl): Pure Julia computer algebra system with support for fast and sparse analytical derivatives
+- [brianguenter/FastDifferentiation.jl](https://github.com/brianguenter/FastDifferentiation.jl): Generate efficient executables for symbolic derivatives
 
-- [FiniteDifferences.jl](https://github.com/JuliaDiff/FiniteDifferences.jl): High-accuracy finite differencing with support for almost any type (not just arrays and numbers).
-- [FiniteDiff.jl](https://github.com/JuliaDiff/FiniteDiff.jl): High-accuracy finite differencing with support for efficient calculation of sparse Jacobians via coloring vectors.
-- [Calculus.jl](https://github.com/JuliaMath/Calculus.jl): Largely deprecated, legacy package. New users should look to FiniteDifferences.jl and FiniteDiff.jl instead.
+### Numeric differentiation
+
+- [JuliaDiff/FiniteDifferences.jl](https://github.com/JuliaDiff/FiniteDifferences.jl): Finite differences with support for arbitrary types and higher order schemes
+- [JuliaDiff/FiniteDiff.jl](https://github.com/JuliaDiff/FiniteDiff.jl): Finite differences with support for caching and sparsity
+
+### Higher order
+
+- [JuliaDiff/TaylorSeries.jl](https://github.com/JuliaDiff/TaylorSeries.jl): Taylor polynomial expansions in one or more variables
+- [JuliaDiff/TaylorDiff.jl](https://github.com/JuliaDiff/TaylorDiff.jl): Higher order directional derivatives (experimental)
 
 ### Rulesets
-Packages providing collections of derivatives of functions which can be used in AD packages.
-- [ChainRules](https://www.juliadiff.org/ChainRulesCore.jl/stable/): Extensible, AD-independent rules.
-  - [ChainRulesCore.jl](https://github.com/JuliaDiff/ChainRulesCore.jl): Core API for user to extend to add rules to their package.
-  - [ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl/): Rules for Julia Base and standard libraries.
-  - [ChainRulesTestUtils.jl](https://github.com/JuliaDiff/ChainRulesTestUtils.jl/): Tools for testing rules defined with ChainRulesCore.jl.
-- [DiffRules.jl](https://github.com/JuliaDiff/DiffRules.jl): An earlier set of AD-independent rules, for scalar functions. Used as the primary source for ForwardDiff.jl, and in part by other packages.
-- [ZygoteRules.jl](https://github.com/FluxML/ZygoteRules.jl): Lightweight package for defining rules for Zygote.jl. Largely deprecated in favour of the AD-independent ChainRulesCore.jl.
 
-### Sparsity
-- [SparsityDetection.jl](https://github.com/SciML/SparsityDetection.jl): Automatic Jacobian and Hessian sparsity pattern detection.
-- [SparseDiffTools.jl](https://github.com/JuliaDiff/SparseDiffTools.jl): Exploiting sparsity to speed up FiniteDiff.jl and ForwardDiff.jl, as well as other algorithms.
+These packages define derivatives for basic functions, and enable users to do the same:
+
+- [JuliaDiff/ChainRules](https://www.juliadiff.org/ChainRulesCore.jl/stable/): Ecosystem for backend-agnostic forward and reverse rules.
+  - [JuliaDiff/ChainRulesCore.jl](https://github.com/JuliaDiff/ChainRulesCore.jl): Core API for users to add rules to their package.
+  - [JuliaDiff/ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl/): Rules for Julia Base and standard libraries.
+  - [JuliaDiff/ChainRulesTestUtils.jl](https://github.com/JuliaDiff/ChainRulesTestUtils.jl/): Tools for testing rules defined with ChainRulesCore.jl.
+- [ThummeTo/ForwardDiffChainRules.jl](https://github.com/ThummeTo/ForwardDiffChainRules.jl): Translate rules from ChainRulesCore.jl to make them compatible with ForwardDiff.jl
+- [JuliaDiff/DiffRules.jl](https://github.com/JuliaDiff/DiffRules.jl): Scalar rules used by ForwardDiff.jl
+- [FluxML/ZygoteRules.jl](https://github.com/FluxML/ZygoteRules.jl): Some rules used by Zygote.jl (mostly deprecated in favor of ChainRules.jl).
 
 ### Interface
-- [AbstractDifferentiation.jl](https://github.com/JuliaDiff/AbstractDifferentiation.jl): AD backend-agnostic interface for algorithms that rely on derivatives, gradients, Jacobians, Hessians, etc.
 
-## Links for discussion and more information
-Discussions on JuliaDiff and its uses may be directed to the [Julia Discourse forum](https://discourse.julialang.org/)
-The [autodiff.org](http://www.autodiff.org/) site serves as a portal for the academic community, though it is often out-of-date.
-The ChainRules project maintains a [list of recommend reading/watching](https://www.juliadiff.org/ChainRulesCore.jl/stable/FAQ.html#Where-can-I-learn-more-about-AD-?) for those after more information.
-Finally, automatic differentiation techniques have been implemented in a variety of languages.
-If you would prefer not to use Julia, see the [wikipedia page](http://en.wikipedia.org/wiki/Automatic_differentiation) for a comprehensive list of available packages.
+- [AbstractDifferentiation.jl](https://github.com/JuliaDiff/AbstractDifferentiation.jl): Backend-agnostic interface for algorithms that rely on derivatives, gradients, Jacobians, Hessians, etc.
+
+### Exotic
+
+- [JuliaDiff/SparseDiffTools.jl](https://github.com/JuliaDiff/SparseDiffTools.jl): Exploit sparsity to speed up FiniteDiff.jl and ForwardDiff.jl, as well as other algorithms.
+- [gaurav-arya/StochasticAD.jl](https://github.com/gaurav-arya/StochasticAD.jl): Differentiation of functions with stochastic behavior (experimental)
+
+### Differentiating through more stuff
+
+Some complex algorithms are not natively differentiable, which is why derivatives have been implemented in the following packages:
+
+- [SciML](https://github.com/SciML): For a lot of different domains of scientific machine learning: differential equations, linear and nonlinear systems, optimization problems, etc.
+- [TuringLang/DistributionsAD.jl](https://github.com/TuringLang/DistributionsAD.jl): For probability distributions
+- [gdalle/ImplicitDifferentiation.jl](https://github.com/gdalle/ImplicitDifferentiation.jl): For generic algorithms specified by output conditions, thanks to the implicit function theorem
+- [jump-dev/DiffOpt.jl](https://github.com/jump-dev/DiffOpt.jl): For convex optimization problems
+- [axelparmentier/InferOpt.jl](https://github.com/axelparmentier/InferOpt.jl): For combinatorial optimization problems
+
+### Inactive packages
+
+- [denizyuret/AutoGrad.jl](https://github.com/denizyuret/AutoGrad.jl)
+- [dfdx/XGrad.jl](https://github.com/dfdx/XGrad.jl)
+- [dpsanders/ReversePropagation.jl](https://github.com/dpsanders/ReversePropagation.jl)
+- [GiggleLiu/NiLang.jl](https://github.com/GiggleLiu/NiLang.jl)
+- [invenia/Nabla.jl](https://github.com/invenia/Nabla.jl/)
+- [JuliaDiff/DualNumbers.jl](https://github.com/JuliaDiff/DualNumbers.jl)
+- [JuliaMath/Calculus.jl](https://github.com/JuliaMath/Calculus.jl)
+- [rejuvyesh/PyCallChainRules.jl](https://github.com/rejuvyesh/PyCallChainRules.jl)
+- [SciML/SparsityDetection.jl](https://github.com/SciML/SparsityDetection.jl)
+- [YingboMa/ForwardDiff2](https://github.com/YingboMa//ForwardDiff2.jl)
+
+[^1]: namely, multiple dispatch, source code via reflection, just-in-time compilation, and first-class access to expression parsing

--- a/index.md
+++ b/index.md
@@ -80,7 +80,7 @@ These packages define derivatives for basic functions, and enable users to do th
   - [JuliaDiff/ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl/): Rules for Julia Base and standard libraries.
   - [JuliaDiff/ChainRulesTestUtils.jl](https://github.com/JuliaDiff/ChainRulesTestUtils.jl/): Tools for testing rules defined with ChainRulesCore.jl.
 - [ThummeTo/ForwardDiffChainRules.jl](https://github.com/ThummeTo/ForwardDiffChainRules.jl): Translate rules from ChainRulesCore.jl to make them compatible with ForwardDiff.jl
-- [JuliaDiff/DiffRules.jl](https://github.com/JuliaDiff/DiffRules.jl): Scalar rules used by e.g. ForwardDiff.jl, ReverseDiff.jl, Zygote.jl, Tracker.jl, and Symbolics.jl
+- [JuliaDiff/DiffRules.jl](https://github.com/JuliaDiff/DiffRules.jl): Scalar rules used by e.g. ForwardDiff.jl, ReverseDiff.jl, Tracker.jl, and Symbolics.jl
 - [FluxML/ZygoteRules.jl](https://github.com/FluxML/ZygoteRules.jl): Some rules used by Zygote.jl (mostly deprecated in favor of ChainRules.jl).
 
 ### Interface

--- a/index.md
+++ b/index.md
@@ -96,7 +96,6 @@ These packages define derivatives for basic functions, and enable users to do th
 Some complex algorithms are not natively differentiable, which is why derivatives have been implemented in the following packages:
 
 - [SciML](https://github.com/SciML): For a lot of different domains of scientific machine learning: differential equations, linear and nonlinear systems, optimization problems, etc.
-- [TuringLang/DistributionsAD.jl](https://github.com/TuringLang/DistributionsAD.jl): For probability distributions
 - [gdalle/ImplicitDifferentiation.jl](https://github.com/gdalle/ImplicitDifferentiation.jl): For generic algorithms specified by output conditions, thanks to the implicit function theorem
 - [jump-dev/DiffOpt.jl](https://github.com/jump-dev/DiffOpt.jl): For convex optimization problems
 - [axelparmentier/InferOpt.jl](https://github.com/axelparmentier/InferOpt.jl): For combinatorial optimization problems

--- a/index.md
+++ b/index.md
@@ -69,6 +69,7 @@ It is worth investigating each package yourself to really understand its ins and
 
 - [JuliaDiff/TaylorSeries.jl](https://github.com/JuliaDiff/TaylorSeries.jl): Taylor polynomial expansions in one or more variables
 - [JuliaDiff/TaylorDiff.jl](https://github.com/JuliaDiff/TaylorDiff.jl): Higher order directional derivatives (experimental)
+- [JuliaDiff/Diffractor.jl](https://github.com/JuliaDiff/Diffractor.jl): Source transformation AD backend (experimental)
 
 ### Rulesets
 

--- a/index.md
+++ b/index.md
@@ -79,7 +79,7 @@ These packages define derivatives for basic functions, and enable users to do th
   - [JuliaDiff/ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl/): Rules for Julia Base and standard libraries.
   - [JuliaDiff/ChainRulesTestUtils.jl](https://github.com/JuliaDiff/ChainRulesTestUtils.jl/): Tools for testing rules defined with ChainRulesCore.jl.
 - [ThummeTo/ForwardDiffChainRules.jl](https://github.com/ThummeTo/ForwardDiffChainRules.jl): Translate rules from ChainRulesCore.jl to make them compatible with ForwardDiff.jl
-- [JuliaDiff/DiffRules.jl](https://github.com/JuliaDiff/DiffRules.jl): Scalar rules used by ForwardDiff.jl
+- [JuliaDiff/DiffRules.jl](https://github.com/JuliaDiff/DiffRules.jl): Scalar rules used by ForwardDiff.jl, ReverseDiff.jl, and Tracker.jl
 - [FluxML/ZygoteRules.jl](https://github.com/FluxML/ZygoteRules.jl): Some rules used by Zygote.jl (mostly deprecated in favor of ChainRules.jl).
 
 ### Interface


### PR DESCRIPTION
Big update on the webpage to make it more accessible to newcomers:

- Revamp the introduction to present all differentation paradigms
- Remove most technicalities and add links to expository papers instead
- Trim package list by putting inactive ones at the bottom
- Add new packages that were not present
- Add whole new section on differentiating through solvers
- Add my name to the author list (if that's okay)